### PR TITLE
[CASSH SERVER] v1.8.0 : Python3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://medium.com/leboncoin-engineering-blog/cassh-ssh-key-signing-tool-39fd3b8
 
   - [CLI version : **1.6.2** *(23/05/2019)*](src/client/CHANGELOG.md)
   - [WebUI version : **1.0.1** *(22/05/2019)*](src/server/web/CHANGELOG.md)
-  - [Server version : **1.7.3** *(27/05/2019)*](src/server/CHANGELOG.md)
+  - [Server version : **1.8.0** *(27/05/2019)*](src/server/CHANGELOG.md)
 
 ## Usage
 
@@ -98,12 +98,10 @@ realname = ursula.ser@domain.fr
 ### Server
 
 ```bash
-# Install cassh python 2 service dependencies
-sudo apt-get install libsasl2-dev python-dev libldap2-dev libssl-dev libpq-dev
-sudo apt-get install python-pip
-pip install -r srx/server/requirements.txt
-# or
-sudo apt-get install python-psycopg2 python-webpy python-ldap python-configparser python-requests python-openssl
+# Install cassh python 3 service dependencies
+sudo apt-get install openssh-client openssl libldap2-dev libsasl2-dev
+sudo apt-get install python3-pip
+pip3 install -r src/server/requirements.txt
 
 # Generate CA ssh key and revocation key file
 mkdir test-keys
@@ -119,6 +117,12 @@ krl = /etc/cassh/krl/revoked-keys
 port = 8080
 # Optionnal : admin_db_failover is used to bypass db when it fails.
 # admin_db_failover = False
+# Optionnal : cluster is used to list the cluster member
+# cluster = http://192.168.0.1:8080,http://192.168.0.2:8080
+# Optionnal : clustersecret is the shared secret used by cluster member
+# clustersecret = clustersecretpassword
+# Optionnal : debug is used to enable the debug. Should not be used into production
+# debug = True
 
 [postgres]
 host = cassh.domain.fr

--- a/src/server/CHANGELOG.md
+++ b/src/server/CHANGELOG.md
@@ -4,6 +4,25 @@ CHANGELOG
 CASSH Server
 -----
 
+1.8.0
+-----
+
+2019/05/27
+
+### New Features
+  - Python 3.6 support :
+    - remove  __future__
+    - use urllib.parse instead of urllib for unquote_plus
+    - web.data output in encoded in UTF-8
+    - Used .keys() for dict
+    - write temporary files in unicode
+    - check_output in returning an unicode output
+
+### Changes
+  - Python 2.x deprecated
+  - Used web.py version 0.40-dev1 instead of 0.39
+
+
 1.7.3
 -----
 

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -1,8 +1,6 @@
-FROM debian:latest
+FROM python:3.6
 
-# Container options (For layer optim)
 WORKDIR /opt/cassh
-ENTRYPOINT ["/opt/cassh/server/docker-entrypoint"]
 
 RUN apt-get update \
     && apt-get install -yqq \
@@ -10,9 +8,13 @@ RUN apt-get update \
         openssl \
         libldap2-dev \
         libsasl2-dev \
-        python-pip \
     && rm -rf /var/lib/apt/lists/*
 
-COPY . server/
 
-RUN pip install -r server/requirements.txt
+COPY requirements.txt ./
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD [ "python", "./server.py" ]

--- a/src/server/requirements.txt
+++ b/src/server/requirements.txt
@@ -2,4 +2,4 @@ configparser==3.7.4
 psycopg2-binary==2.8.2
 python-ldap==3.2.0
 requests==2.22.0
-web.py==0.39
+web.py==0.40-dev1

--- a/src/server/ssh_utils/__init__.py
+++ b/src/server/ssh_utils/__init__.py
@@ -12,7 +12,7 @@ def get_fingerprint(public_key_filename):
         fingerprint = '\n'.join(check_output([
             'ssh-keygen',
             '-l',
-            '-f', public_key_filename]).split('\n')[:-1])
+            '-f', public_key_filename]).decode('utf-8').split('\n')[:-1])
     except CalledProcessError:
         fingerprint = 'Unknown'
     return fingerprint

--- a/src/server/tools/__init__.py
+++ b/src/server/tools/__init__.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """ tools lib """
 
-from __future__ import print_function
 from datetime import datetime, timedelta
 from json import dumps
 from os import stat
@@ -9,7 +8,7 @@ from random import choice
 from shutil import move
 from string import ascii_lowercase
 from time import time
-from urllib import unquote_plus
+from urllib.parse import unquote_plus
 
 # Third party library imports
 from psycopg2 import connect, OperationalError, ProgrammingError


### PR DESCRIPTION
CASSH Server
-----

1.8.0
-----

2019/05/27

### New Features
  - Python 3.6 support :
    - remove  `__future__`
    - use urllib.parse instead of urllib for unquote_plus
    - web.data output in encoded in UTF-8
    - Used .keys() for dict
    - write temporary files in unicode
    - check_output in returning an unicode output

### Changes
  - Python 2.x deprecated
  - Used web.py version 0.40-dev1 instead of 0.39