### PR TITLE
Add new 'set' admin actions, Add 'search' admin action and fix cassh …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.* ]]; then pip install pylint; pip install -r src/client/requirements.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3.* ]]; then pip3 install pylint; pip3 install -r src/client/requirements.txt; fi
 # command to run tests
-script: pylint src/client/cassh -d redefined-builtin -d useless-object-inheritance
+script: pylint src/client/cassh -d redefined-builtin -d useless-object-inheritance -d too-many-branches

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Developped for @leboncoin
 
 https://medium.com/leboncoin-engineering-blog/cassh-ssh-key-signing-tool-39fd3b8e4de7
 
-  - [CLI version : **1.6.3** *(24/01/2020)*](src/client/CHANGELOG.md)
+  - [CLI version : **1.7.0** *(24/03/2020)*](src/client/CHANGELOG.md)
   - [WebUI version : **1.1.1** *(24/01/2020)*](src/server/web/CHANGELOG.md)
-  - [Server version : **1.11.0** *(23/03/2020)*](src/server/CHANGELOG.md)
+  - [Server version : **1.12.0** *(24/03/2020)*](src/server/CHANGELOG.md)
 
 ## Usage
 
@@ -42,6 +42,39 @@ cassh krl
 
 ### Admin CLI
 
+```
+usage: cassh admin [-h] [-s SET] [--add-principals ADD_PRINCIPALS]
+                   [--remove-principals REMOVE_PRINCIPALS]
+                   [--purge-principals]
+                   [--update-principals UPDATE_PRINCIPALS]
+                   [--principals-filter PRINCIPALS_FILTER]
+                   username action
+
+positional arguments:
+  username              Username of client's key, if username is 'all' status
+                        return all users
+  action                Choice between : active, delete, revoke, set, search,
+                        status keys
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -s SET, --set SET     CAUTION: Set value of a user.
+  --add-principals ADD_PRINCIPALS
+                        Add a list of principals to a user, should be
+                        separated by comma without spaces.
+  --remove-principals REMOVE_PRINCIPALS
+                        Remove a list of principals to a user, should be
+                        separated by comma without spaces.
+  --purge-principals    Purge all principals to a user.
+  --update-principals UPDATE_PRINCIPALS
+                        Update all principals to a user by the given
+                        principals, should be separated by comma without
+                        spaces.
+  --principals-filter PRINCIPALS_FILTER
+                        Look for users by the given principals filter, should
+                        be separated by comma without spaces.
+```
+
 Active Client **username** key :
 ```
 cassh admin <username> active
@@ -64,8 +97,25 @@ cassh admin <username> status
 
 Set Client **username** key :
 ```
+# Set exipry to 7 days
 cassh admin <username> set --set='expiry=+7d'
-cassh admin <username> set --set='principals=username,root'
+
+# Add principals to existing ones
+cassh admin <username> set --add-principals foo,bar
+
+# Remove principals from existing ones
+cassh admin <username> set --remove-principals foo,bar
+
+# Update principals and erease existsing ones
+cassh admin <username> set --update-principals foo,bar
+
+# Purge principals
+cassh admin <username> set --purge-principals
+```
+
+Search **Principals** among clients :
+```
+cassh admin all search --principals-filter foo,bar
 ```
 
 ### Configuration file

--- a/src/client/CHANGELOG.md
+++ b/src/client/CHANGELOG.md
@@ -4,6 +4,20 @@ CHANGELOG
 CASSH Client
 -----
 
+1.7.0
+-----
+
+2020/01/24
+
+### New Features
+
+  - Add --add-principals, --remove-principals, --purge-principals and --update-principals for the admin 'set' action. It's replacing the deprecate 'set' action: `--set='principals=foo,bar`.
+  - Add --principals-filter for the admin 'search' action.
+
+### Changes
+  - Validate username in the admin command
+
+
 1.6.3
 -----
 

--- a/src/client/cassh
+++ b/src/client/cassh
@@ -17,8 +17,9 @@ from getpass import getpass
 from json import dumps, loads
 from os import chmod, getenv
 from os.path import isfile
+from re import compile as re_compile
 from shutil import copyfile
-from sys import argv, exit
+import sys
 
 # Third party library imports
 from configparser import ConfigParser, NoOptionError, NoSectionError
@@ -28,7 +29,9 @@ from requests.exceptions import ConnectionError
 # Debug
 # from pdb import set_trace as st
 
-VERSION = '%(prog)s 1.6.3'
+VERSION = '%(prog)s 1.7.0'
+
+PATTERN_USERNAME = re_compile("^([a-z]+)$")
 
 def print_result(result):
     """ Display result """
@@ -60,7 +63,7 @@ def read_conf(conf_path):
     except NoOptionError as error_msg:
         print('Can\'t read configuration file...')
         print(error_msg)
-        exit(1)
+        sys.exit(1)
 
     if not config.has_option('user', 'timeout'):
         user_metadata['timeout'] = 2
@@ -74,7 +77,7 @@ def read_conf(conf_path):
 
     if user_metadata['key_path'] == user_metadata['key_signed_path']:
         print('You should put a different path for key_path and key_signed_path.')
-        exit(1)
+        sys.exit(1)
 
     try:
         user_metadata['auth'] = 'ldap'
@@ -82,7 +85,7 @@ def read_conf(conf_path):
     except NoOptionError as error_msg:
         print('Can\'t read configuration file...')
         print(error_msg)
-        exit(1)
+        sys.exit(1)
     except NoSectionError:
         user_metadata['auth'] = None
         user_metadata['realname'] = None
@@ -96,9 +99,23 @@ def read_conf(conf_path):
 
     if not isfile(user_metadata['key_path']):
         print('File %s doesn\'t exists' % user_metadata['key_path'])
-        exit(1)
+        sys.exit(1)
 
     return user_metadata
+
+def get_set_value(arguments):
+    """
+    Returns the chosen value of 'set' action
+    """
+    if arguments.add_principals:
+        return 'add', arguments.add_principals
+    if arguments.remove_principals:
+        return 'remove', arguments.remove_principals
+    if arguments.update_principals:
+        return 'update', arguments.update_principals
+    if arguments.purge_principals:
+        return 'purge', arguments.purge_principals
+    return 'deprecated', arguments.set
 
 class CASSH(object):
     """
@@ -135,7 +152,7 @@ class CASSH(object):
                                       verify=self.user_metadata['verify'])
         except ConnectionError:
             print('Connection error : %s' % self.user_metadata['url'])
-            exit(1)
+            sys.exit(1)
         return req
 
     def get(self, uri):
@@ -149,7 +166,7 @@ class CASSH(object):
                                    verify=self.user_metadata['verify'])
         except ConnectionError:
             print('Connection error : %s' % self.user_metadata['url'])
-            exit(1)
+            sys.exit(1)
         return req
 
     def patch(self, uri, data):
@@ -164,7 +181,7 @@ class CASSH(object):
                                      verify=self.user_metadata['verify'])
         except ConnectionError:
             print('Connection error : %s' % self.user_metadata['url'])
-            exit(1)
+            sys.exit(1)
         return req
 
     def post(self, uri, data):
@@ -179,7 +196,7 @@ class CASSH(object):
                                     verify=self.user_metadata['verify'])
         except ConnectionError:
             print('Connection error : %s' % self.user_metadata['url'])
-            exit(1)
+            sys.exit(1)
         return req
 
     def put(self, uri, data):
@@ -194,7 +211,7 @@ class CASSH(object):
                                    verify=self.user_metadata['verify'])
         except ConnectionError:
             print('Connection error : %s' % self.user_metadata['url'])
-            exit(1)
+            sys.exit(1)
         return req
 
     ########################
@@ -215,10 +232,13 @@ class CASSH(object):
             data.update(prefix)
         return data
 
-    def admin(self, username, action, set_value=None):
+    def admin(self, username, action, set_value, search_value):
         """
         Admin CLI
         """
+        if PATTERN_USERNAME.match(username) is None:
+            print('Username not valid')
+            sys.exit(1)
         payload = self.get_data()
         if action == 'revoke':
             payload.update({'revoke': True})
@@ -228,10 +248,17 @@ class CASSH(object):
         elif action == 'delete':
             req = self.delete('/admin/' + username, payload)
         elif action == 'set':
-            set_value_dict = {}
-            set_value_dict[set_value.split('=')[0]] = set_value.split('=')[1]
-            payload.update(set_value_dict)
-            req = self.patch('/admin/' + username, payload)
+            if set_value[0] == 'deprecated':
+                set_value_dict = {}
+                set_value_dict[set_value.split('=')[0]] = set_value.split('=')[1]
+                payload.update(set_value_dict)
+                req = self.patch('/admin/' + username, payload)
+            else:
+                payload.update({set_value[0]: set_value[1]})
+                req = self.post('/admin/' + username + '/principals', payload)
+        elif action == 'search':
+            payload.update({'filter': search_value})
+            req = self.post('/admin/all/principals/search', payload)
         elif action == 'status':
             payload.update({'status': True})
             req = self.post('/admin/' + username, payload)
@@ -250,8 +277,8 @@ class CASSH(object):
             print_result(result)
             return
         else:
-            print('Action should be : revoke, active, delete or status')
-            exit(1)
+            print('Action should be : active, delete, revoke, set, search, status')
+            sys.exit(1)
         print(req.text)
 
     def add(self):
@@ -280,7 +307,7 @@ class CASSH(object):
         req = self.post('/client', payload)
         if not 'ssh-' in req.text and not 'ecdsa-' in req.text:
             print(req.text)
-            exit(1)
+            sys.exit(1)
         if do_write_on_disk:
             key_signed_path = self.user_metadata['key_signed_path']
             copyfile(self.key_path, key_signed_path)
@@ -333,13 +360,25 @@ if __name__ == '__main__':
 
     # ADMIN Arguments
     ADMIN_PARSER = SUBPARSERS.add_parser('admin',\
-        help='Administrator command : active - revoke - delete - status - set keys')
+        help='Administrator command : active, delete, revoke, set, search, status keys')
     ADMIN_PARSER.add_argument('username', action='store',\
         help='Username of client\'s key, if username is \'all\' status return all users')
     ADMIN_PARSER.add_argument('action', action='store',\
-        help='Choice between : active - revoke - delete - status - set')
+        help='Choice between : active, delete, revoke, set, search, status keys')
     ADMIN_PARSER.add_argument('-s', '--set', action='store',\
         help='CAUTION: Set value of a user.')
+    ADMIN_PARSER.add_argument('--add-principals', action='store',\
+        help='Add a list of principals to a user, should be separated by comma without spaces.')
+    ADMIN_PARSER.add_argument('--remove-principals', action='store',\
+        help='Remove a list of principals to a user, should be separated by comma without spaces.')
+    ADMIN_PARSER.add_argument('--purge-principals', action='store_true',\
+        help='Purge all principals to a user.')
+    ADMIN_PARSER.add_argument('--update-principals', action='store',\
+        help='Update all principals to a user by the given principals, \
+        should be separated by comma without spaces.')
+    ADMIN_PARSER.add_argument('--principals-filter', action='store',\
+        help='Look for users by the given principals filter, \
+        should be separated by comma without spaces.')
 
     # ADD Arguments
     ADD_PARSER = SUBPARSERS.add_parser('add', help='Add a key to remote ssh ca server.')
@@ -391,25 +430,32 @@ if __name__ == '__main__':
         print('# realname : this is the LDAP/AD login user')
         print('realname = ursula.ser@domain.fr')
         print('enable = True')
-        exit(1)
+        sys.exit(1)
 
     CLIENT = CASSH(read_conf(CONF_FILE))
 
-    if len(argv) == 1:
+    if len(sys.argv) == 1:
         PARSER.print_help()
-        exit(1)
+        sys.exit(1)
 
-    if argv[1] == 'add':
+    if sys.argv[1] == 'add':
         CLIENT.add()
-    elif argv[1] == 'sign':
+    elif sys.argv[1] == 'sign':
         CLIENT.sign(not ARGS.display_only, force=ARGS.force)
-    elif argv[1] == 'status':
+    elif sys.argv[1] == 'status':
         CLIENT.status()
-    elif argv[1] == 'ca':
+    elif sys.argv[1] == 'ca':
         CLIENT.get_ca()
-    elif argv[1] == 'krl':
+    elif sys.argv[1] == 'krl':
         CLIENT.get_krl()
-    elif argv[1] == 'admin':
-        CLIENT.admin(ARGS.username, ARGS.action, set_value=ARGS.set)
+    elif sys.argv[1] == 'admin':
+        CLIENT.admin(
+            ARGS.username,
+            ARGS.action,
+            get_set_value(ARGS),
+            ARGS.principals_filter)
+    else:
+        PARSER.print_help()
+        sys.exit(1)
 
-    exit(0)
+    sys.exit(0)

--- a/src/server/CHANGELOG.md
+++ b/src/server/CHANGELOG.md
@@ -4,6 +4,20 @@ CHANGELOG
 CASSH Server
 -----
 
+1.12.0
+-----
+
+2020/03/24
+
+
+### Changes
+  - New user starts with its username as principal
+  - Purge set the username as principals, instead of nothing
+
+### Bug Fixes
+  - Unquote action values for Principals and PrincipalsSearch
+  - Allow multiple actions for Principals
+
 1.11.0
 -----
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -57,7 +57,7 @@ URLS = (
     '/test_auth', 'TestAuth',
 )
 
-VERSION = '1.11.0'
+VERSION = '1.12.0'
 
 PARSER = ArgumentParser()
 PARSER.add_argument('-c', '--config', action='store', help='Configuration file')
@@ -567,7 +567,7 @@ class Client():
         if user is None:
             cur.execute('INSERT INTO USERS VALUES \
                 ((%s), (%s), (%s), (%s), (%s), (%s), (%s), (%s))', \
-                (username, realname, 2, 0, pubkey_fingerprint, pubkey, '+12h', ''))
+                (username, realname, 2, 0, pubkey_fingerprint, pubkey, '+12h', username))
             pg_conn.commit()
             cur.close()
             pg_conn.close()
@@ -702,6 +702,14 @@ class Principals():
 
         payload = data2map()
 
+        if 'add' not in payload and \
+            'remove' not in payload and \
+            'update' not in payload and \
+            'purge' not in payload:
+            return response_render(
+                '[ERROR] Unknown action',
+                http_code='400 Bad Request')
+
         if PATTERN_USERNAME.match(username) is None:
             return response_render(
                 "Error: username doesn't match pattern {}".format(PATTERN_USERNAME.pattern),
@@ -724,6 +732,7 @@ class Principals():
         values['principals'] = user[1]
 
         for key, value in payload.items():
+            value = unquote_plus(value)
             if key == 'add':
                 for principal in value.split(','):
                     if PATTERN_PRINCIPALS.match(principal) is None:
@@ -755,20 +764,16 @@ class Principals():
                             http_code='400 Bad Request')
                 values['principals'] = value
             elif key == 'purge':
-                values['principals'] = ''
-            else:
-                return response_render(
-                    '[ERROR] Unknown action',
-                    http_code='400 Bad Request')
+                values['principals'] = username
 
-            cur.execute(
-                """
-                UPDATE USERS SET PRINCIPALS=(%(principals)s) WHERE NAME=(%(username)s)
-                """, values)
-            pg_conn.commit()
-            cur.close()
-            pg_conn.close()
-            return response_render("OK: {} principals are '{}'".format(username, values['principals']))
+        cur.execute(
+            """
+            UPDATE USERS SET PRINCIPALS=(%(principals)s) WHERE NAME=(%(username)s)
+            """, values)
+        pg_conn.commit()
+        cur.close()
+        pg_conn.close()
+        return response_render("OK: {} principals are '{}'".format(username, values['principals']))
 
 
 class PrincipalsSearch():
@@ -791,6 +796,11 @@ class PrincipalsSearch():
 
         payload = data2map()
 
+        if 'filter' not in payload:
+            return response_render(
+                '[ERROR] Unknown action',
+                http_code='400 Bad Request')
+
         cur.execute(
             """
             SELECT NAME,PRINCIPALS FROM USERS
@@ -803,6 +813,7 @@ class PrincipalsSearch():
         result = dict()
 
         for key, value in payload.items():
+            value = unquote_plus(value)
             if key == 'filter':
                 if value == '':
                     for name, principals in all_principals:
@@ -819,10 +830,6 @@ class PrincipalsSearch():
                             if name not in result:
                                 result[name] = list()
                             result[name].append(principal)
-            else:
-                return response_render(
-                    '[ERROR] Unknown action',
-                    http_code='400 Bad Request')
 
         return response_render("OK: {}".format(result))
 

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -817,7 +817,8 @@ class PrincipalsSearch():
             if key == 'filter':
                 if value == '':
                     for name, principals in all_principals:
-                        result[name] = principals.split(',')
+                        if isinstance(principals, str):
+                            result[name] = principals.split(',')
                     continue
                 for principal in value.split(','):
                     if PATTERN_PRINCIPALS.match(principal) is None:
@@ -826,12 +827,12 @@ class PrincipalsSearch():
                                 PATTERN_PRINCIPALS.pattern),
                             http_code='400 Bad Request')
                     for name, principals in all_principals:
-                        if principal in principals.split(','):
+                        if isinstance(principals, str) and principal in principals.split(','):
                             if name not in result:
                                 result[name] = list()
                             result[name].append(principal)
 
-        return response_render("OK: {}".format(result))
+        return response_render(dumps(result))
 
 
 class TestAuth():

--- a/tests/test_principals.sh
+++ b/tests/test_principals.sh
@@ -81,17 +81,10 @@ fi
 
 
 RESP=$(curl -s -X POST "${CASSH_SERVER_URL}"/admin/"${USER2}"/principals -d "purge=true")
-if [ "${RESP}" == "OK: ${USER2} principals are ''" ]; then
+if [ "${RESP}" == "OK: ${USER2} principals are '${USER2}'" ]; then
     echo "[OK] Test purge principals to ${USER2}"
 else
     echo "[FAIL] Test purge principals to ${USER2} : ${RESP}"
-fi
-
-RESP=$(curl -s -X POST "${CASSH_SERVER_URL}"/admin/"${USER2}"/principals -d "add=${USER2}")
-if [ "${RESP}" == "OK: ${USER2} principals are '${USER2}'" ]; then
-    echo "[OK] Test add principal '${USER2}' to ${USER2}"
-else
-    echo "[FAIL] Test add principal '${USER2}' to ${USER2} : ${RESP}"
 fi
 
 RESP=$(curl -s -X POST "${CASSH_SERVER_URL}"/admin/"${USER2}"/principals -d "add=test-multiple-a,test-multiple-b")

--- a/tests/test_principals_search.sh
+++ b/tests/test_principals_search.sh
@@ -21,7 +21,7 @@ else
     echo "[FAIL] Test search single principal : ${RESP}"
 fi
 
-RESP=$(curl -s -X POST "${CASSH_SERVER_URL}"/admin/"${USER3}"/principals -d "add=${USER3},test-multiple-${USER2}")
+RESP=$(curl -s -X POST "${CASSH_SERVER_URL}"/admin/"${USER3}"/principals -d "add=test-multiple-${USER2}")
 if [ "${RESP}" == "OK: ${USER3} principals are '${USER3},test-multiple-${USER2}'" ]; then
     echo "[OK] Test add principal 'test-multiple-${USER2}' to ${USER3}"
 else

--- a/tests/test_principals_search.sh
+++ b/tests/test_principals_search.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 
 RESP=$(curl -s -X POST "${CASSH_SERVER_URL}"/admin/all/principals/search -d "filter=")
-if [[ "${RESP}" == *"OK: {'"* ]]; then
+if [[ "${RESP}" == *"{\""* ]]; then
     echo "[OK] Test search all users' principals"
 else
     echo "[FAIL] Test search all users' principals : ${RESP}"
 fi
 
 RESP=$(curl -s -X POST "${CASSH_SERVER_URL}"/admin/all/principals/search -d "filter=dontexists")
-if [ "${RESP}" == "OK: {}" ]; then
+if [ "${RESP}" == "{}" ]; then
     echo "[OK] Test search unknown principals"
 else
     echo "[FAIL] Test search unknown principals : ${RESP}"
 fi
 
 RESP=$(curl -s -X POST "${CASSH_SERVER_URL}"/admin/all/principals/search -d "filter=test-multiple-${USER2}")
-if [ "${RESP}" == "OK: {'${USER2}': ['test-multiple-${USER2}']}" ]; then
+if [ "${RESP}" == "{\"${USER2}\": [\"test-multiple-${USER2}\"]}" ]; then
     echo "[OK] Test search single principal"
 else
     echo "[FAIL] Test search single principal : ${RESP}"
@@ -29,14 +29,14 @@ else
 fi
 
 RESP=$(curl -s -X POST "${CASSH_SERVER_URL}"/admin/all/principals/search -d "filter=test-multiple-${USER2}")
-if [[ "${RESP}" == *"'${USER3}': ['test-multiple-${USER2}'"* ]] && [[ "${RESP}" == *"'${USER2}': ['test-multiple-${USER2}'"* ]]; then
+if [[ "${RESP}" == *"\"${USER3}\": [\"test-multiple-${USER2}\""* ]] && [[ "${RESP}" == *"\"${USER2}\": [\"test-multiple-${USER2}\""* ]]; then
     echo "[OK] Test search single principals with multiple users"
 else
     echo "[FAIL] Test search single principals with multiple users : ${RESP}"
 fi
 
 RESP=$(curl -s -X POST "${CASSH_SERVER_URL}"/admin/all/principals/search -d "filter=test-multiple-${USER2},unknown")
-if [[ "${RESP}" == *"'${USER3}': ['test-multiple-${USER2}'"* ]] && [[ "${RESP}" == *"'${USER2}': ['test-multiple-${USER2}'"* ]]; then
+if [[ "${RESP}" == *"\"${USER3}\": [\"test-multiple-${USER2}\""* ]] && [[ "${RESP}" == *"\"${USER2}\": [\"test-multiple-${USER2}\""* ]]; then
     echo "[OK] Test search multiple principals with one unknown"
 else
     echo "[FAIL] Test search multiple principals with one unknown : ${RESP}"
@@ -57,7 +57,7 @@ else
 fi
 
 RESP=$(curl -s -X POST "${CASSH_SERVER_URL}"/admin/all/principals/search -d "filter=test-multiple-${USER2},${USER3}")
-if [[ "${RESP}" == *"'${USER3}': ['${USER3}'"* ]] && [[ "${RESP}" == *"'${USER2}': ['test-multiple-${USER2}'"* ]]; then
+if [[ "${RESP}" == *"\"${USER3}\": [\"${USER3}\""* ]] && [[ "${RESP}" == *"\"${USER2}\": [\"test-multiple-${USER2}\""* ]]; then
     echo "[OK] Test search multiple principals with multiple users"
 else
     echo "[FAIL] Test search multiple principals with multiple users : ${RESP}"


### PR DESCRIPTION
CASSH Client
-----

1.7.0
-----

2020/01/24

### New Features

  - Add --add-principals, --remove-principals, --purge-principals and --update-principals for the admin 'set' action. It's replacing the deprecate 'set' action: `--set='principals=foo,bar`.
  - Add --principals-filter for the admin 'search' action.

### Changes
  - Validate username in the admin command

CASSH Server
-----

1.12.0
-----

2020/03/24


### Changes
  - New user starts with its username as principal
  - Purge set the username as principals, instead of nothing

### Bug Fixes
  - Unquote action values for Principals and PrincipalsSearch
  - Allow multiple actions for Principals