### PR TITLE
Cassh Server v2.1.0: Fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://medium.com/leboncoin-engineering-blog/cassh-ssh-key-signing-tool-39fd3b8
 
   - [CLI version : **1.7.0** *(24/03/2020)*](src/client/CHANGELOG.md) ![leboncoin/cassh](https://img.shields.io/docker/pulls/leboncoin/cassh) + ![nbeguier/cassh-client](https://img.shields.io/docker/pulls/nbeguier/cassh-client) [![docker-build](https://img.shields.io/docker/cloud/automated/nbeguier/cassh-client)](https://hub.docker.com/r/nbeguier/cassh-client)
   - [WebUI version : **1.1.1** *(24/01/2020)*](src/server/web/CHANGELOG.md) ![nbeguier/cassh-web](https://img.shields.io/docker/pulls/nbeguier/cassh-web) [![docker-build](https://img.shields.io/docker/cloud/automated/nbeguier/cassh-web)](https://hub.docker.com/r/nbeguier/cassh-web)
-  - [Server version : **2.0.2** *(09/04/2020)*](src/server/CHANGELOG.md) ![leboncoin/cassh-server](https://img.shields.io/docker/pulls/leboncoin/cassh-server) + ![nbeguier/cassh-server](https://img.shields.io/docker/pulls/nbeguier/cassh-server) [![docker-build](https://img.shields.io/docker/cloud/automated/nbeguier/cassh-server)](https://hub.docker.com/r/nbeguier/cassh-server)
+  - [Server version : **2.1.0** *(21/09/2020)*](src/server/CHANGELOG.md) ![leboncoin/cassh-server](https://img.shields.io/docker/pulls/leboncoin/cassh-server) + ![nbeguier/cassh-server](https://img.shields.io/docker/pulls/nbeguier/cassh-server) [![docker-build](https://img.shields.io/docker/cloud/automated/nbeguier/cassh-server)](https://hub.docker.com/r/nbeguier/cassh-server)
 
 ## Usage
 

--- a/src/server/CHANGELOG.md
+++ b/src/server/CHANGELOG.md
@@ -4,6 +4,15 @@ CHANGELOG
 CASSH Server
 -----
 
+2.1.0
+-----
+
+2020/09/21
+
+### Changes
+  - Compare ssh public fingerprint instead of raw content
+  - Force sha512 during fingerprint, instead of default hash algorithm
+
 2.0.2
 -----
 

--- a/src/server/ssh_utils/__init__.py
+++ b/src/server/ssh_utils/__init__.py
@@ -16,10 +16,11 @@ def get_fingerprint(public_key_filename):
     Returns a key fingerprint
     """
     try:
-        fingerprint = '\n'.join(check_output([
+        fingerprint = ' '.join(check_output([
             'ssh-keygen',
             '-l',
-            '-f', public_key_filename]).decode('utf-8').split('\n')[:-1])
+            '-E', 'sha512',
+            '-f', public_key_filename]).decode('utf-8').split('\n')[0].split()[:2])
     except CalledProcessError:
         fingerprint = 'Unknown'
     return fingerprint

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -30,6 +30,7 @@ GUEST_A_PASSWORD=hG9%60P%3AJznneDcTfN%7D6KLr%2DV%5Ev%24EKR%3CDrx%22qj%28%5C%2Bf 
 
 # USER: guest.b
 GUEST_B_PUB_KEY=$(cat "${KEY_3_EXAMPLE}".pub)
+GUEST_B_ALT_PUB_KEY=$(cat "${KEY_3_EXAMPLE}".pub | awk '{print $1" "$2" some-random-comment"}')
 GUEST_B_USERNAME=guestb$(pwgen -A -0 10)
 GUEST_B_REALNAME=guest.b@example.org
 GUEST_B_PASSWORD=ohwie6aegohghaegho2zed2kah6gaajeiV0ThahQu6oogukaevei4eeh9co0aiyeem9baeKeeh1ohphae9ies0ahx0Eechuij4osaej5ahchei1Jo2gaze2ahch3ohpiyie4hai4ohdi0fohx2akae4ooChohce1Thieg4shoosh9epae9ainooy1uepaad1gei1pheongaunie0mohy3Ich9eetohn1ni9johzaiMoan8sha7eish6Gee

--- a/tests/test_admin_activate.sh
+++ b/tests/test_admin_activate.sh
@@ -92,7 +92,7 @@ else
 fi
 
 RESP=$(curl -s -X POST -d "username=${GUEST_A_USERNAME}&realname=${GUEST_B_REALNAME}&password=${GUEST_B_PASSWORD}&pubkey=${GUEST_A_PUB_KEY}" "${CASSH_SERVER_URL}"/client)
-if [ "${RESP}" == 'Error : (username, realname) couple mismatch.' ]; then
+if [ "${RESP}" == 'Error : (username, realname, pubkey) triple mismatch.' ]; then
     echo "[OK] Test signing key when revoked with wrong realname"
 else
     echo "[FAIL ${BASH_SOURCE}:+${LINENO}] Test signing key when revoked with wrong realname: ${RESP}"

--- a/tests/test_client_sign_error.sh
+++ b/tests/test_client_sign_error.sh
@@ -37,7 +37,7 @@ else
 fi
 
 RESP=$(curl -s -X POST -d "username=${GUEST_A_USERNAME}&realname=${GUEST_A_REALNAME}&password=${GUEST_A_PASSWORD}&pubkey=${GUEST_B_PUB_KEY}" "${CASSH_SERVER_URL}"/client)
-if [ "${RESP}" == 'Error : User or Key absent, add your key again.' ]; then
+if [ "${RESP}" == 'Error : (username, realname, pubkey) triple mismatch.' ]; then
     echo "[OK] Test signing key when wrong public key"
 else
     echo "[FAIL ${BASH_SOURCE}:+${LINENO}] Test signing key when wrong public key : ${RESP}"

--- a/tests/test_principals.sh
+++ b/tests/test_principals.sh
@@ -56,6 +56,15 @@ else
 fi
 rm -f /tmp/test-cert
 
+RESP=$(curl -s -X POST -d "username=${GUEST_B_USERNAME}&realname=${GUEST_B_REALNAME}&password=${GUEST_B_PASSWORD}&pubkey=${GUEST_B_ALT_PUB_KEY}" "${CASSH_SERVER_URL}"/client)
+echo "${RESP}" > /tmp/test-cert
+OUTPUT=$(echo $(echo -n "$(ssh-keygen -L -f /tmp/test-cert 2>&1)"))
+if [[ "${OUTPUT}" == *"Principals: ${GUEST_B_USERNAME} test-single guest-everywhere Critical"* ]]; then
+    echo "[OK] Test signing key with altered public key"
+else
+    echo "[FAIL ${BASH_SOURCE}:+${LINENO}] Test signing key with altered public key: ${OUTPUT}"
+fi
+rm -f /tmp/test-cert
 
 RESP=$(curl -s -X POST -d "realname=${SYSADMIN_REALNAME}&password=${SYSADMIN_PASSWORD}" "${CASSH_SERVER_URL}"/admin/"${GUEST_B_USERNAME}"/principals -d "add=test-single")
 if [ "${RESP}" == "OK: ${GUEST_B_USERNAME} principals are '${GUEST_B_USERNAME},test-single,guest-everywhere'" ]; then


### PR DESCRIPTION
CASSH Server
-----

2.1.0
-----

2020/09/21

### Changes
  - Compare ssh public fingerprint instead of raw content
  - Force sha512 during fingerprint, instead of default hash algorithm
