### PR TITLE
Multikey status

### DIFF
--- a/src/client/cassh
+++ b/src/client/cassh
@@ -270,11 +270,8 @@ class CASSH(object):
             if result == {}:
                 print(dumps(result, indent=4, sort_keys=True))
                 return
-            if username == 'all':
-                for user in result:
-                    print_result(result[user])
-                return
-            print_result(result)
+            for user in result.keys():
+                print_result(result[user])
             return
         else:
             print('Action should be : active, delete, revoke, set, search, status')
@@ -330,7 +327,8 @@ class CASSH(object):
         if result == {}:
             print(dumps(result, indent=4, sort_keys=True))
             return
-        print_result(result)
+        for user in result.keys():
+            print_result(result[user])
 
     def get_ca(self):
         """

--- a/src/server/lib/tools.py
+++ b/src/server/lib/tools.py
@@ -601,21 +601,24 @@ class Tools():
         if pg_conn is None:
             return response_render(message, http_code='503 Service Unavailable')
         cur = pg_conn.cursor()
-        is_list = False
 
-        if realname is not None:
+        if realname is not None and username is not None:
+            cur.execute('SELECT * FROM USERS WHERE REALNAME=(%s) and NAME=(%s)', (realname,username,))
+            result = [cur.fetchone()]
+        elif realname is not None:
             cur.execute('SELECT * FROM USERS WHERE REALNAME=(%s)', (realname,))
-            result = cur.fetchone()
+            result = cur.fetchall()
         elif username is not None:
             cur.execute('SELECT * FROM USERS WHERE NAME=(%s)', (username,))
-            result = cur.fetchone()
+            result = [cur.fetchone()]
         else:
             cur.execute('SELECT * FROM USERS')
             result = cur.fetchall()
-            is_list = True
         cur.close()
         pg_conn.close()
-        return self.sql_to_json(result, is_list=is_list)
+        print(result,realname,username)
+        k = self.sql_to_json(result, is_list=True)
+        return k
 
     def pg_connection(self):
         """

--- a/src/server/web/cassh_web.py
+++ b/src/server/web/cassh_web.py
@@ -194,12 +194,13 @@ def cassh_status(current_user=None):
         return Response('Connection error : %s' % APP.config['CASSH_URL'])
     try:
         result = loads(req.text)
-        is_expired = datetime.strptime(result['expiration'], '%Y-%m-%d %H:%M:%S') < datetime.now()
-        if result['status'] == 'ACTIVE':
-            if is_expired:
-                result['status'] = 'EXPIRED'
-            else:
-                result['status'] = 'SIGNED'
+        for r in result.values():
+            is_expired = datetime.strptime(r['expiration'], '%Y-%m-%d %H:%M:%S') < datetime.now()
+            if r['status'] == 'ACTIVE':
+                if is_expired:
+                    r['status'] = 'EXPIRED'
+                else:
+                    r['status'] = 'SIGNED'
     except:
         result = req.text
 

--- a/src/server/web/templates/status.html
+++ b/src/server/web/templates/status.html
@@ -5,16 +5,20 @@
 {% block content %}
 
 {% if logged_in %}
-<div class="datagrid"><table>
-<thead><tr><th>Login</th><th>{{ result.realname }}</th></tr></thead>
-<tbody><tr><td>Status</td><td>{{ result.status }}</td></tr>
-<tr class="alt"><td>Expiration</td><td>{{ result.expiration }}</td></tr>
-<tbody><tr><td>SSH Key Hash</td><td>{{ result.ssh_key_hash }}</td></tr>
-<tr class="alt"><td>Username</td><td>{{ result.username }}</td></tr>
-<tbody><tr><td>Expiry</td><td>{{ result.expiry }}</td></tr>
-<tr class="alt"><td>Principals</td><td>{{ result.principals }}</td></tr>
+<div class="datagrid">
+{% for r in result.values() %}
+<table>
+<thead><tr><th>Login</th><th>{{ r.realname }}</th></tr></thead>
+<tbody><tr><td>Status</td><td>{{ r.status }}</td></tr>
+<tr class="alt"><td>Expiration</td><td>{{ r.expiration }}</td></tr>
+<tbody><tr><td>SSH Key Hash</td><td>{{ r.ssh_key_hash }}</td></tr>
+<tr class="alt"><td>Username</td><td>{{ r.username }}</td></tr>
+<tbody><tr><td>Expiry</td><td>{{ r.expiry }}</td></tr>
+<tr class="alt"><td>Principals</td><td>{{ r.principals }}</td></tr>
 </tbody>
-</table></div>
+</table>
+{% endfor %}
+</div>
 {% else %}
 <strong>Log in first !</strong>
 {% endif %}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -61,7 +61,7 @@ else
 fi
 
 RESP=$(curl -s -X POST -d "realname=${GUEST_A_REALNAME}&password=${GUEST_A_PASSWORD}" "${CASSH_SERVER_URL}"/client/status)
-if [ "${RESP}" == 'None' ]; then
+if [ "${RESP}" == '{}' ]; then
     echo "[OK] Test status unknown user"
 else
     echo "[FAIL ${BASH_SOURCE}:+${LINENO}] Test status unknown user : ${RESP}"

--- a/tests/test_admin_activate.sh
+++ b/tests/test_admin_activate.sh
@@ -77,7 +77,7 @@ fi
 ##########################
 ## ADMIN STATUS GUEST A ##
 ##########################
-RESP=$(curl -s -X POST -d "status=true&realname=${SYSADMIN_REALNAME}&password=${SYSADMIN_PASSWORD}" "${CASSH_SERVER_URL}"/admin/"${GUEST_A_USERNAME}" | jq .status)
+RESP=$(curl -s -X POST -d "status=true&realname=${SYSADMIN_REALNAME}&password=${SYSADMIN_PASSWORD}" "${CASSH_SERVER_URL}"/admin/"${GUEST_A_USERNAME}" | jq '.[]|.status')
 if [ "${RESP}" == '"REVOKED"' ]; then
     echo "[OK] Test admin verify '${GUEST_A_USERNAME}' status"
 else
@@ -150,7 +150,7 @@ else
     echo "[FAIL ${BASH_SOURCE}:+${LINENO}] Test admin active '${GUEST_B_USERNAME}' status with unauthorized user: ${RESP}"
 fi
 
-RESP=$(curl -s -X POST -d "status=true&realname=${SYSADMIN_REALNAME}&password=${SYSADMIN_PASSWORD}" "${CASSH_SERVER_URL}"/admin/"${GUEST_B_USERNAME}" | jq .status)
+RESP=$(curl -s -X POST -d "status=true&realname=${SYSADMIN_REALNAME}&password=${SYSADMIN_PASSWORD}" "${CASSH_SERVER_URL}"/admin/"${GUEST_B_USERNAME}" | jq '.[] | .status')
 if [ "${RESP}" == '"PENDING"' ]; then
     echo "[OK] Test admin verify '${GUEST_B_USERNAME}' status"
 else
@@ -182,6 +182,16 @@ if [ "${RESP}" == "Active user=${GUEST_C_USERNAME}. SSH Key active but need to b
     echo "[OK] Test admin active ${GUEST_C_USERNAME}"
 else
     echo "[FAIL ${BASH_SOURCE}:+${LINENO}] Test admin active ${GUEST_C_USERNAME} : ${RESP}"
+fi
+
+#######################################
+## STATUS GUEST B WITH MULTIPLE KEYS ##
+#######################################
+RESP=$(curl -s -X POST -d "realname=${GUEST_B_REALNAME}&password=${GUEST_B_PASSWORD}" "${CASSH_SERVER_URL}"/client/status | jq '.[] | .status')
+if [ "${RESP}" == $'"ACTIVE"\n"ACTIVE"' ]; then
+    echo "[OK] Test status pending user"
+else
+    echo "[FAIL ${BASH_SOURCE}:+${LINENO}] Test status pending user : ${RESP}"
 fi
 
 #############################

--- a/tests/test_client_add.sh
+++ b/tests/test_client_add.sh
@@ -121,7 +121,7 @@ fi
 ####################
 ## STATUS GUEST A ##
 ####################
-RESP=$(curl -s -X POST -d "realname=${GUEST_A_REALNAME}&password=${GUEST_A_PASSWORD}" "${CASSH_SERVER_URL}"/client/status | jq .status)
+RESP=$(curl -s -X POST -d "realname=${GUEST_A_REALNAME}&password=${GUEST_A_PASSWORD}" "${CASSH_SERVER_URL}"/client/status | jq '.[] | .status')
 if [ "${RESP}" == '"PENDING"' ]; then
     echo "[OK] Test status pending user"
 else


### PR DESCRIPTION
Hi,
I've added the ability to display multiple keys for the same realname in the status page.

This imply a small API change in the `client/status` endpoint. In a previous implementation I've tried to preserve the original API
but it then become difficult to handle the response.  So I've come up with this version.

The ability to associate multiple keys with one realname is already present on mainline, it was missing only the status page which was displaying only the last one.