### PR TITLE
Add initialvaliditydate support

### DIFF
--- a/src/server/INSTALL.md
+++ b/src/server/INSTALL.md
@@ -50,3 +50,12 @@ filter_memberof_key = memberOf
 # username_prefix = cn=
 # username_suffix = ,dc=example,dc=org
 ```
+### Initial validity date
+
+Allows to specify an initial validity date for the generated certificates
+instead of today, useful for systems without a reliable clock source
+
+```ini
+[main]
+keyvalidityintervalstart = 20220101
+```

--- a/src/server/conf/cassh.conf
+++ b/src/server/conf/cassh.conf
@@ -5,6 +5,7 @@ port = 8080
 cluster = http://localhost:8080,http://localhost:8081
 clustersecret = clustersecretpassword
 debug = False
+#keyvalidityintervalstart = None
 
 [postgres]
 host = localhost

--- a/src/server/lib/constants.py
+++ b/src/server/lib/constants.py
@@ -18,7 +18,7 @@ STATES = {
     'PENDING': 2,
 }
 
-PATTERN_EXPIRY = re_compile('^([0-9]+)+[dh]$')
+PATTERN_EXPIRY = re_compile('^([0-9]+)+[dh]|([0-9]+){8}$')
 PATTERN_PRINCIPALS = re_compile(r'^([a-zA-Z-\d]+)$')
 PATTERN_REALNAME = re_compile(
     r"(^[-!#$%&'*+/=?^_`{}|~0-9A-Z]+(\.[-!#$%&'*+/=?^_`{}|~0-9A-Z]+)*"


### PR DESCRIPTION
I've added a configuration field to be able to specify an initial date for the generated certificates.

Use case is embedded systems where the clock might get backward due to battery problems and no internet connection, without this settings any user using certificate auth won't be able to login anymore
                                                                      